### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Patched
+- Quick fix for `trade_deadline` attribute in `Settings` class. Will search for better alternative.
+
 
 ## [1.3.1] - 2017-07-24
 ### Added

--- a/espnff/espnff.py
+++ b/espnff/espnff.py
@@ -186,8 +186,10 @@ class Settings(object):
         self.playoff_team_count = data['leaguesettings']['playoffTeamCount']
         self.id = data['leaguesettings']['id']
         self.keeper_count = data['leaguesettings']['futureKeeperCount']
-        try: self.trade_deadline = data['leaguesettings']['tradeDeadline']
-        except: self.trade_deadline = 'Unknown'
+        try:
+            self.trade_deadline = data['leaguesettings']['tradeDeadline']
+        except:
+            self.trade_deadline = 'Unknown'
         self.name = data['leaguesettings']['name']
         self.status = data['metadata']['status']
         self.year = data['metadata']['seasonId']

--- a/espnff/espnff.py
+++ b/espnff/espnff.py
@@ -186,7 +186,8 @@ class Settings(object):
         self.playoff_team_count = data['leaguesettings']['playoffTeamCount']
         self.id = data['leaguesettings']['id']
         self.keeper_count = data['leaguesettings']['futureKeeperCount']
-        self.trade_deadline = data['leaguesettings']['tradeDeadline']
+        try: self.trade_deadline = data['leaguesettings']['tradeDeadline']
+        except: self.trade_deadline = 'Unknown'
         self.name = data['leaguesettings']['name']
         self.status = data['metadata']['status']
         self.year = data['metadata']['seasonId']

--- a/espnff/tests/test_league.json
+++ b/espnff/tests/test_league.json
@@ -625,7 +625,6 @@
       "usingUndroppableList":true,
       "draftPickTradingEnabled":false,
       "waiverProcessDays":123,
-      "tradeDeadline":"2016-11-19T17:00:00.000Z",
       "waiverHours":24,
       "playoffMatchupLength":1,
       "vetoVotesRequired":4,


### PR DESCRIPTION
This pull request has a quick fix for the `trade_deadline` attribute in `Settings` class. Will find a better alternative in the future.