### PR TITLE
Add client for private league authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,102 @@
-.pyc
+# IDE
+.idea
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/espnff/__init__.py
+++ b/espnff/__init__.py
@@ -1,14 +1,17 @@
-__all__ = ['League',
-           'Team',
-           'Settings',
-           'Matchup',
-           'ESPNFFException',
-           'PrivateLeagueException',
-           'InvalidLeagueException',
-           'UnknownLeagueException'
-           ]
+__all__ = [
+    'ESPNFF',
+    'League',
+    'Team',
+    'Settings',
+    'Matchup',
+    'ESPNFFException',
+    'PrivateLeagueException',
+    'InvalidLeagueException',
+    'UnknownLeagueException'
+]
 
 from .league import League
+from .client import ESPNFF
 from .team import Team
 from .settings import Settings
 from .matchup import Matchup

--- a/espnff/client.py
+++ b/espnff/client.py
@@ -1,0 +1,45 @@
+import requests
+from espnff import League
+from espnff.exception import AuthorizationError
+
+
+class ESPNFF:
+    def __init__(self, username=None, password=None):
+        self.__username = username
+        self.__password = password
+        self.__auth_swid = None
+        self.__auth_s2 = None
+
+    def authorize(self):
+        headers = {'Content-Type': 'application/json'}
+        r = requests.post(
+            'https://registerdisney.go.com/jgc/v5/client/ESPN-FANTASYLM-PROD/api-key?langPref=en-US',
+            headers=headers
+        )
+
+        if r.status_code != 200 or 'api-key' not in r.headers:
+            raise AuthorizationError('failed to get API key')
+
+        api_key = r.headers['api-key']
+        headers['authorization'] = 'APIKEY ' + api_key
+
+        payload = {'loginValue': self.__username, 'password': self.__password}
+
+        r = requests.post(
+            'https://ha.registerdisney.go.com/jgc/v5/client/ESPN-FANTASYLM-PROD/guest/login?langPref=en-US',
+            headers=headers, json=payload
+        )
+
+        if r.status_code != 200:
+            raise AuthorizationError('unable to authorize')
+
+        data = r.json()
+
+        if data['error'] is not None:
+            raise AuthorizationError('unable to obtain autorization')
+
+        self.__auth_swid = data['data']['profile']['swid']
+        self.__auth_s2 = data['data']['s2']
+
+    def get_league(self, league_id, year):
+        return League(league_id, year, self.__auth_s2, self.__auth_swid)

--- a/espnff/exception.py
+++ b/espnff/exception.py
@@ -12,3 +12,7 @@ class InvalidLeagueException(ESPNFFException):
 
 class UnknownLeagueException(ESPNFFException):
     pass
+
+
+class AuthorizationError(Exception):
+    pass

--- a/espnff/league.py
+++ b/espnff/league.py
@@ -11,7 +11,7 @@ from .exception import (PrivateLeagueException,
 
 
 class League(object):
-    '''Creates a League instance for Public ESPN league'''
+    '''Creates a League instance for ESPN league'''
     def __init__(self, league_id, year, espn_s2=None, swid=None):
         self.league_id = league_id
         self.year = year

--- a/tests/test_client.json
+++ b/tests/test_client.json
@@ -1,0 +1,108 @@
+{
+  "data": {
+    "etag": "W/\"eyJwcm9maWxlRVRhZyI6ImViY2Y5M2RkM2QyZDQ1N2ZiOWY0M2IwNDk4NzQ0YTkxIiwiZGlzcGxheU5hbWVFVGFnIjoiNTZmYzFiOGNhODU0YWQ3MDg5ZWQwY2Y4OWQ1NTRkYWIifQ==\"",
+    "profile": {
+      "swid": "{0F8E9869-7220-4C50-97CF-C53A4E2D1C2D}",
+      "referenceId": "2497682e-fdd3-4f38-91d6-933f445f0a51",
+      "testProfileFlag": "N",
+      "username": "doem5503927",
+      "prefix": null,
+      "firstName": "John",
+      "middleName": null,
+      "lastName": "Doe",
+      "suffix": null,
+      "languagePreference": null,
+      "region": null,
+      "email": "<removed>",
+      "parentEmail": null,
+      "dateOfBirth": "1996-11-07",
+      "gender": "1",
+      "ageBand": "ADULT",
+      "ageBandAssumed": false,
+      "countryCodeDetected": "US",
+      "emailVerified": false,
+      "parentEmailVerified": false,
+      "registrationDate": "2017-03-13T17:18:23.943Z",
+      "linkedAccountsAvailable": false,
+      "complete": false,
+      "status": "ACTIVE",
+      "addresses": null,
+      "phones": null,
+      "pronunciationName": null,
+      "isShareable": true,
+      "isAdultVerified": false
+    },
+    "displayName": {
+      "displayName": "John\n        Doe",
+      "proposedDisplayName": "John Doe",
+      "proposedStatus": "NONE",
+      "moderatedStatusDate": "2017-03-14\n        17:09:28.25"
+    },
+    "geolocation": null,
+    "linkedAccounts": null,
+    "accountMapping": {},
+    "marketing": [
+      {
+        "code": "WDIGFamilySites",
+        "subscribed": true,
+        "status": "accepted",
+        "textID": null
+      },
+      {
+        "code": "ESPNFantasyGeneralNews",
+        "subscribed": true,
+        "status": "accepted",
+        "textID": null
+      },
+      {
+        "code": "ESPN_Level1_GeneralPermission",
+        "subscribed": true,
+        "status": "accepted",
+        "textID": null
+      },
+      {
+        "code": "ESPN_Insider_NLO",
+        "subscribed": true,
+        "status": "accepted",
+        "textID": null
+      },
+      {
+        "code": "ESPN_TCMen_Allstate_2017",
+        "subscribed": true,
+        "status": "accepted",
+        "textID": null
+      },
+      {
+        "code": "ESPN3rdPartySponsors",
+        "subscribed": false,
+        "status": "declined",
+        "textID": null
+      }
+    ],
+    "entitlements": [
+      {
+        "digitalAssetName": "ESPN_INSIDER",
+        "digitalAssetSourceName": "SZPREM",
+        "assetId": 11,
+        "productId": 1,
+        "expirationDate": null,
+        "effectiveDate": "2017-03-13T17:20:10.000+0000"
+      }
+    ],
+    "s2": "AEBdR%2Fa0%2FazkV18gssdJnWqI66723hbNcLfDbH86wqKY4qjizsE9qIzBATZmv08OgxjfXH8Q1uEpWmmcjPLUG7CfE84xU%2FArE4FmIGcNbsWR9gmJBzK%2BYtfLwgIIb6CPIG9Dm5XG8wnewBu3mTCkcHVavvjlg1UDuuT0Qqdv4odGIZK0ejLQjxFci7WnpsbIJ5gyjUp7D%2Fr8jeCEoQsr5tHYQmSjzBHQezSe3ujbTZ7WMniIasDAinPi7MDlWjMoivod6RIWq6PH6mp6cWAaE2ywndNN9JyaYusZ3b1Ze2QlxCp6w%3D%3D",
+    "token": {
+      "access_token": "ffcb32e84aed4448b8ca5bec7b12e86d",
+      "refresh_token": "734ca4bac803456293b0d349492d0f64",
+      "swid": "{0F8E9869-7220-4C50-97CF-C53A4E2D1C2D}",
+      "ttl": 86400,
+      "refresh_ttl": 2592000,
+      "scope": "AUTHZ_GUEST_SECURED_SESSION\n        disneyid-accountmapper-guest disneyid-accountmapper-guest-create disneyid-accountmapper-guest-read\n        disneyid-compliance-guest-read-information disneyid-compliance-guest-read-permissions\n        disneyid-compliance-guest-update-permissions disneyid-displayname-guest-update\n        disneyid-family-guest-create disneyid-family-guest-dissolve disneyid-family-guest-modify\n        disneyid-family-guest-read disneyid-profile-guest-disable disneyid-profile-guest-emailclickback\n        disneyid-profile-guest-read disneyid-profile-guest-recovery disneyid-profile-guest-update\n        disneyid-trustdomain-guest-register-sso-session dtss-entitlement-user-admin",
+      "sso": null,
+      "blue_cookie": "iVoOefaqHaI0zhvHAbKzi#64WS$hNA781TwxR6nyvOVarwHWulQOUnzgBi1Q3uVCBTVUbC3K4ZNfCcZbwg2mKOplv6mHZnh$Db1amJkqFmSJM#$IJsD68SgFoiV#MYKOiR$Tu7$TX00USQiYo6wV6AfE#sBYpj0A0eoALdxkjQsIUU4Z#4qb2Ucspy42nwofaUO3TBPNDMjUG0kWIza90OsfpiMl6ZeHNXMPyy5CSR9xjEmfgZjD5EyAc1PwSRmYfpBwWpXcqLk",
+      "authenticator": "disneyid",
+      "loginValue": null,
+      "clickbackType": null
+    }
+  },
+  "error": null
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,30 @@
+import json
+import unittest
+import requests_mock
+from espnff.client import ESPNFF
+from espnff.exception import AuthorizationError
+
+
+class ESPNFFTestCase(unittest.TestCase):
+    """Test ESPNFF Client"""
+    @requests_mock.Mocker()
+    def test_authorize(self, m):
+        m.post(
+            'https://registerdisney.go.com/jgc/v5/client/ESPN-FANTASYLM-PROD/api-key?langPref=en-US',
+            status_code=200, headers={'api-key': '<API_KEY>'}
+        )
+
+        with open('tests/test_client.json') as f:
+            data = json.load(f)
+
+        m.post(
+            'https://ha.registerdisney.go.com/jgc/v5/client/ESPN-FANTASYLM-PROD/guest/login?langPref=en-US',
+            status_code=200, json=data
+        )
+
+        espnff = ESPNFF('<username>', '<password>')
+
+        try:
+            espnff.authorize()
+        except AuthorizationError:
+            self.fail('authorize() raised AuthorizationError unexpectedly')


### PR DESCRIPTION
This adds an ESPNFF client that can be used to authorize against the ESPNFF API using username and password. Once authorized, a private league can be fetched.

Usage:
```
from espnff import ESPNFF

client = ESPNFF('<username>', '<password>')
try:
    client.authorize()
except AuthorizationError:
    print('failed to authorize')

client.get_league('<league_id>', '<year>')
```
I'll leave it to someone else to document properly in the README.

Side note: This project suffers from a lot of PEP8 errors, so I suggest someone cleans it up (I recommend flake8). There are also a few other things, such as non-closed files during tests and wrong doc notation (should be 3 double quotes, not single quotes). Would clean it up myself but don't wanna do something that will later get rejected in case the repo owner wants things his way :)