### PR TITLE
Added general roster functionality

### DIFF
--- a/espnff/__init__.py
+++ b/espnff/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ['League',
            'Team',
+           'Player',
            'Settings',
            'Matchup',
            'ESPNFFException',
@@ -8,6 +9,7 @@ __all__ = ['League',
            'UnknownLeagueException'
            ]
 
+from .player import Player
 from .league import League
 from .team import Team
 from .settings import Settings

--- a/espnff/league.py
+++ b/espnff/league.py
@@ -2,6 +2,7 @@ import requests
 
 from .utils import (two_step_dominance,
                     power_points, )
+from .player import Player
 from .team import Team
 from .settings import Settings
 from .matchup import Matchup
@@ -51,6 +52,7 @@ class League(object):
             raise UnknownLeagueException('Unknown %s Error' % self.status)
 
         self._fetch_teams(data)
+        self._fetch_rosters()
         self._fetch_settings(data)
 
     def _fetch_teams(self, data):
@@ -75,6 +77,41 @@ class League(object):
 
         # sort by team ID
         self.teams = sorted(self.teams, key=lambda x: x.team_id, reverse=False)
+
+    def _fetch_rosters(self):
+        team_ids = str([team.team_id for team in self.teams]).replace("[", "").replace("]", "").replace(" ", "")
+
+        params = {
+            'leagueId': self.league_id,
+            'seasonId': self.year,
+            'teamIds': team_ids
+        }
+
+        r = requests.get('%srosterInfo' % (self.ENDPOINT,), params=params)
+        self.roster_status = r.status_code
+        data = r.json()
+
+        if self.roster_status != 200:
+            raise UnknownLeagueException('Unknown %s Error' % self.roster_status)
+
+
+        #map team_id to list index. if self.teams is converted to dictionary, this would not be needed
+        team_id_map = dict([(team.team_id, pos) for pos, team in enumerate(self.teams, 0)])
+
+        fetched_teams = data['leagueRosters']['teams']
+
+        for fetched_team in fetched_teams:
+            #pull current team from teams list using the map created above
+            current_team = self.teams[team_id_map[fetched_team['teamId']]]
+
+            for player in fetched_team['slots']:
+                try:
+                    self.first_name = player['player']
+                except KeyError:
+                    #empty slot on roster, skip
+                    continue
+                new_player = Player(player)
+                current_team.roster.append(new_player)
 
     def _fetch_settings(self, data):
         self.settings = Settings(data)

--- a/espnff/player.py
+++ b/espnff/player.py
@@ -1,3 +1,21 @@
 class Player(object):
-    def __init__(sef, data):
-        return None
+    def __init__(self, data):
+        self.is_on_bench = data['slotCategoryId'] == 20
+        self.first_name = data['player']['firstName']
+        self.last_name = data['player']['lastName']
+        self.current_slot = data['slotCategoryId']
+        self.trade_locked = data['isTradeLocked']
+        self.health_status = data['player']['healthStatus']
+        self.draft_rank = data['player']['draftRank']
+        self.is_active = data['player']['isActive']
+        self.droppable = data['player']['droppable']
+        self.lock_status = data['lockStatus']
+        self.eligible_slots = data['player']['eligibleSlotCategoryIds']
+        self.percent_change = data['player']['percentChange']
+        self.percent_owned = data['player']['percentOwned']
+        self.percent_started = data['player']['percentStarted']
+        self.player_id = data['player']['playerId']
+        self.pro_team_id = data['player']['proTeamId']
+
+    def __repr__(self):
+        return 'Player(%s)' % (self.first_name + " " + self.last_name + " " + str(self.player_id),)

--- a/espnff/team.py
+++ b/espnff/team.py
@@ -15,6 +15,7 @@ class Team(object):
         self.schedule = []
         self.scores = []
         self.mov = []
+        self.roster = []
         self._fetch_schedule(data)
 
     def __repr__(self):


### PR DESCRIPTION
Pulls all of the teams rosters in one GET. Creates a Player object for each player on a team, and adds it to the roster list in the Team object.

In the future, its probably better to create a Roster object based off of the roster map that is created in the Settings object by using their associated 'slotCategoryId'. 

some params for rosterInfo:

rosterInfo?
leagueId=XXXX
includeProjectionText=true
includeOwnPotentialTradeTransactions=false
includeRankings=true
includeLatestNews=true
scoringPeriodId=X (this is the week)
teamIds=X
usePreviousSeasonRealStats=false
useCurrentSeasonRealStats=true
useCurrentSeasonProjectedStats=false
useCurrentPeriodRealStats=true
useCurrentPeriodProjectedStats=true
usePreviousPeriodRealStats=true
fromTeamId=X (not sure what this does)
processAverages=false
rand=83501222794203