### PR TITLE
Inactive members power rankings fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 ### Patched
+- Fixed issue where inactive members from past seasons messed up
+power rankings
+
+### Patched
 - Fixed output for possibility the attribute doesn't exist in the API
 
 ### Other

--- a/espnff/league.py
+++ b/espnff/league.py
@@ -87,10 +87,19 @@ class League(object):
         teams_sorted = sorted(self.teams, key=lambda x: x.team_id,
                               reverse=False)
 
+        # deleted members from previous years still hold a team_id, so
+        #    create a new mapping of team id to dominance matrix row/column
+        matrix_position_map = {}
+        count = 0
+        for team in teams_sorted:
+            matrix_position_map[team.team_id] = count
+            count += 1
+
+        # loop through our teams and create a matrix of wins
         for team in teams_sorted:
             wins = [0]*32
             for mov, opponent in zip(team.mov[:week], team.schedule[:week]):
-                opp = int(opponent.team_id)-1
+                opp = matrix_position_map[opponent.team_id]
                 if mov > 0:
                     wins[opp] += 1
             win_matrix.append(wins)


### PR DESCRIPTION
Fixed issue #55 where inactive members from past seasons messed up dominance matrix and thus the power rankings